### PR TITLE
fix: remove type checking for 'exports' callbacks

### DIFF
--- a/src/client/classes/ClFishingPlayer.lua
+++ b/src/client/classes/ClFishingPlayer.lua
@@ -54,9 +54,7 @@ end
 ---@param message string
 ---@param messageType string
 function ClFishingPlayer:ShowMessage(message, messageType)
-    if type(ClFishing.ShowMessage) == "function" then
-        ClFishing.ShowMessage(message, messageType)
-    end
+    ClFishing.ShowMessage(message, messageType)
 end
 
 ---@param message string

--- a/src/client/client.lua
+++ b/src/client/client.lua
@@ -34,9 +34,7 @@ ClFishing = {
 
 ---@type fun(message: string, messageType: string)
 function ClFishing:SetMessageHandler(handler)
-    if type(handler) == "function" then
-        self.ShowMessage = handler
-    end
+    self.ShowMessage = handler
 end
 
 ClFishingPlayer:On("lure", function(data)
@@ -91,37 +89,25 @@ RegisterCommand('fish', function()
 end)
 
 exports('SetShowMessage', function(handler)
-    if type(handler) == "function" then
-        ClFishing.ShowMessage = handler
-    end
+    ClFishing.ShowMessage = handler
 end)
 
 exports('SetOnTestingProgress', function(handler)
-    if type(handler) == "function" then
-        ClFishing.TestingProgress = handler
-    end
+    ClFishing.TestingProgress = handler
 end)
 
 exports('SetOnTestingComplete', function(handler)
-    if type(handler) == "function" then
-        ClFishing.TestingComplete = handler
-    end
+    ClFishing.TestingComplete = handler
 end)
 
 exports('SetCheckRodCallback', function(handler)
-    if type(handler) == "function" then
-        ClFishingPlayer.CheckRodCallback = handler
-    end
+    ClFishingPlayer.CheckRodCallback = handler
 end)
 
 exports('SetOnFishCaught', function(handler)
-    if type(handler) == "function" then
-        ClFishingPlayer.OnFishCaught = handler
-    end
+    ClFishingPlayer.OnFishCaught = handler
 end)
 
 exports('SetOnCatchPending', function(handler)
-    if type(handler) == "function" then
-        ClFishingPlayer.CatchPending = handler
-    end
+    ClFishingPlayer.CatchPending = handler
 end)

--- a/src/server/classes/SvFishingPlayer.lua
+++ b/src/server/classes/SvFishingPlayer.lua
@@ -57,9 +57,5 @@ end
 ---@param name string
 ---@param amount number
 function SvFishingPlayer:AddItem(name, amount)
-    if type(SvFishing.GivePlayerItem) == "function" then
-        SvFishing.GivePlayerItem(self.Source, name, amount)
-    else
-        print("^1[" .. GetCurrentResourceName() .. "]: no add item hook set. please refer to documentation^7")
-    end
+    SvFishing.GivePlayerItem(self.Source, name, amount)
 end

--- a/src/server/server.lua
+++ b/src/server/server.lua
@@ -12,10 +12,8 @@ SvFishing = {
 
 ---@param handler fun(source: number, item: string, amount: number): void
 function SvFishing:SetGiveHandler(handler)
-    if type(handler) == "function" then
-        self.GivePlayerItem = function(source, item, amount)
-            handler(source, item, amount)
-        end
+    self.GivePlayerItem = function(source, item, amount)
+        handler(source, item, amount)
     end
 end
 
@@ -59,9 +57,7 @@ for k,v in pairs(EventHandlers) do
     RegisterNetEvent(eventName)
     AddEventHandler(eventName, function(...)
         local source = source
-        if type(SvFishing[v.Handler]) == "function" then
-            SvFishing[v.Handler](svFishing, source, ...)
-        end
+        SvFishing[v.Handler](svFishing, source, ...)
     end)
 end
 
@@ -72,15 +68,11 @@ RegisterCommand('setlure', function(source, args, raw)
 end)
 
 exports('SetGivePlayerItem', function(handler)
-    if type(handler) == "function" then
-        SvFishing.GivePlayerItem = handler
-    end
+    SvFishing.GivePlayerItem = handler
 end)
 
 exports('SetLureHandler', function(handler)
-    if type(handler) == "function" then
-        SvFishing.SetLureHandler = handler
-    end
+    SvFishing.SetLureHandler = handler
 end)
 
 exports('SetLureForPlayer', function(source, lure)


### PR DESCRIPTION
This pull request removes type checking for passed callbacks via exports.

https://github.com/Cyntaax/fivem-fishing/issues/1